### PR TITLE
Support for Haskell's language server

### DIFF
--- a/generic-debruijn/generic-debruijn.cabal
+++ b/generic-debruijn/generic-debruijn.cabal
@@ -9,7 +9,7 @@ version:             0.1.0.0
 -- description:
 -- bug-reports:
 -- license:
-license-file:        LICENSE
+-- license-file:        LICENSE
 author:              Arnaud Spiwack
 maintainer:          arnaud@spiwack.net
 -- copyright:
@@ -21,5 +21,8 @@ library
   exposed-modules:
         Data.Generics.DeBruijn
   build-depends:       base >=4.13 && <4.14
+                     , generic-lens
+                     , containers
+                     , lens
   hs-source-dirs: src
   default-language:    Haskell2010

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.haskellPackages.haskell-language-server
+    pkgs.ghc
+
+    # keep this line if you use bash
+    pkgs.bashInteractive
+  ];
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,6 @@
-resolver: lts-15.5
+resolver: lts-16.20
+allow-newer: true
+system-ghc: true # run in nix-shell
 
 packages:
 - .
@@ -12,3 +14,6 @@ extra-deps:
 - alex-meta-0.3.0.11@sha256:f436b5283a4380d9cb33f0c3aa67763299042044eaea2779b97b92ddd53e3091,1442
 - happy-meta-0.2.0.10@sha256:525d6f102b3a13478b4014aca9cb253a3bfa7d49ff35f1312fe27c40b1805630,1302
 - capability-0.3.0.0@sha256:0f198c6523b940517670c0ba62e4ee19622c3bb3d8c1b80293e5a882a150b41f,3262
+
+ghc-options:
+  "$everything": -haddock

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,7 @@ resolver: lts-15.5
 
 packages:
 - .
+- generic-debruijn
 - unfix-binders
 - lensy-f
 - refined-experiment

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -34,7 +34,7 @@ packages:
     hackage: capability-0.3.0.0@sha256:0f198c6523b940517670c0ba62e4ee19622c3bb3d8c1b80293e5a882a150b41f,3262
 snapshots:
 - completed:
-    size: 491372
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/5.yaml
-    sha256: 1b549cfff328040c382a70a84a2087aac8dab6d778bf92f32a93a771a1980dfc
-  original: lts-15.5
+    size: 532177
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/20.yaml
+    sha256: 0e14ba5603f01e8496e8984fd84b545a012ca723f51a098c6c9d3694e404dc6d
+  original: lts-16.20


### PR DESCRIPTION
It's all clicked now.

For the time being I assume that `stack` is run inside the nix-shell. But a better way is probably to simply activate the nix support for `stack`, it will allow better reloads.

I'm interested to see how it holds up in streams.