### PR TITLE
Many refactors resulting of today's stream

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,8 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((nil . ((eval . (add-hook 'hack-local-variables-hook
+                           (lambda nil
+                             (when
+                                 (derived-mode-p 'haskell-mode)
+                               (lsp))))))))

--- a/generic-debruijn/src/Data/Generics/DeBruijn.hs
+++ b/generic-debruijn/src/Data/Generics/DeBruijn.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
@@ -34,6 +36,7 @@ import qualified Data.Generics.Product as Generics
 
 -- TODO: in 9.0: add type signature
 newtype Bind (n :: Nat) a = Bind a
+  deriving newtype (Eq, Ord, Show)
 
 -- TODO: should `Bind` have an API similar to the `Syntax` API? It can't quite
 -- share the exact same API because it is not recursive. A traversable API? It

--- a/generic-debruijn/src/Data/Generics/DeBruijn.hs
+++ b/generic-debruijn/src/Data/Generics/DeBruijn.hs
@@ -27,6 +27,8 @@ import qualified Data.Generics.Product as Generics
 -- Historical note: Scrap Your Boilerplate paper: 2003. I know that this style
 -- of programming was there in Coq in Feb 2005 when I first used the code
 -- base. I don't know how long it had been there. Will investigate.
+-- A good explanation of this style in the context of de Bruijn indices can be
+-- found at https://www.twanvl.nl/blog/haskell/traversing-syntax-trees
 
 -- Generalise this way? https://gist.github.com/ekmett/80ea0a22c99577013de8cb6cfe020971
 

--- a/generic-debruijn/src/Data/Generics/DeBruijn.hs
+++ b/generic-debruijn/src/Data/Generics/DeBruijn.hs
@@ -85,20 +85,20 @@ class Syntax (a :: g -> *) where
 
   traverseSubs :: Applicative f => (forall e'. Context a -> a e' -> f (a e')) -> Context a -> a e -> f (a e)
 
--- TODO: throughout: I don't like that the `a` (type) argument happens before
--- the `f` argument. I use it everywhere for consistency, though. Two choices:
--- either I can use type signatures to reorder the argument of `traverseSubs`,
--- despite it being a type class method.  (it was discussed at some point I
--- don't know if it ended up working out), or I can simply duplicate
--- `traverseSubs`: once as the method, to define the type class, and once as a
--- function, to have the convenient (type) argument order.
---
--- TODO: move into the type class in case one needs to override it to avoid the
--- error.
-traverseSubs_ :: forall a f e. (Syntax a, Applicative f) => (forall e'. a e' -> f (a e')) -> a e -> f (a e)
-traverseSubs_ onSubs = traverseSubs (const onSubs) arbitrary
-  where
-    arbitrary = error "traversal accesses context directly, you may want to override the default traverseSubs_ implementation"
+  -- TODO: throughout: I don't like that the `a` (type) argument happens before
+  -- the `f` argument. I use it everywhere for consistency, though. Two choices:
+  -- either I can use type signatures to reorder the argument of `traverseSubs`,
+  -- despite it being a type class method.  (it was discussed at some point I
+  -- don't know if it ended up working out), or I can simply duplicate
+  -- `traverseSubs`: once as the method, to define the type class, and once as a
+  -- function, to have the convenient (type) argument order.
+  --
+  -- TODO: move into the type class in case one needs to override it to avoid the
+  -- error.
+  traverseSubs_ :: (Syntax a, Applicative f) => (forall e'. a e' -> f (a e')) -> a e -> f (a e)
+  traverseSubs_ onSubs = traverseSubs (const onSubs) arbitrary
+    where
+      arbitrary = error "traversal accesses context directly, you may want to override the default traverseSubs_ implementation"
 
 -- TODO: can I make the `g` parameter inferred, so that the first `_` can be
 -- removed? In 9.0. In a delightful twist of fate, `traverseSubs_`'s kind
@@ -115,13 +115,13 @@ mapSubs :: forall a e. (Syntax a) => (forall e'. Context a -> a e' -> a e') -> C
 mapSubs = coerce $ traverseSubs @_ @a @Identity @e
 
 mapSubs_ :: forall a e. (Syntax a) => (forall e'. a e' -> a e') -> a e -> a e
-mapSubs_ = coerce $ traverseSubs_ @a @Identity @e
+mapSubs_ = coerce $ traverseSubs_ @_ @a @Identity @e
 
 foldSubs :: forall a r e. (Syntax a, Monoid r) => (forall e'. Context a -> a e' -> r) -> Context a -> a e -> r
 foldSubs = coerce $ traverseSubs @_ @a @(Const r) @e
 
 foldSubs_ :: forall a r e. (Syntax a, Monoid r) => (forall e'. a e' -> r) -> a e -> r
-foldSubs_ = coerce $ traverseSubs_ @a @(Const r) @e
+foldSubs_ = coerce $ traverseSubs_ @_ @a @(Const r) @e
 
 -- TODO: make abstract
 --

--- a/refined-experiment/app/Main.hs
+++ b/refined-experiment/app/Main.hs
@@ -952,13 +952,12 @@ freeVars :: Expr e -> [Ident]
 freeVars (NVar x) = [ x ]
 freeVars t = Db.foldSubs_ freeVars t
 
+substituteUnder :: [Term] -> Int -> Expr e -> Expr e
+substituteUnder subst lvl u@(Var i) = Maybe.fromMaybe u $ preview (ix i) ((iterate shift subst) !! lvl)
+substituteUnder subst lvl t = Db.mapSubs (substituteUnder subst) lvl t
+
 substitute :: [Term] -> Expr e -> Expr e
-substitute subst (PForall y 𝜏 p) =
-  PForall y 𝜏 (substitute (shift subst) p)
-substitute subst (RSub y 𝜏 p) =
-  RSub y 𝜏 (substitute (shift subst) p)
-substitute subst u@(Var i) = Maybe.fromMaybe u $ preview (ix i) subst
-substitute subst t = Db.mapSubs_ (substitute subst) t
+substitute subst = substituteUnder subst 0
 
 substituteN :: Ident -> Term -> Expr e -> Expr e
 substituteN x t u@(NVar y)

--- a/refined-experiment/app/Main.hs
+++ b/refined-experiment/app/Main.hs
@@ -1263,23 +1263,9 @@ typeInferRefinementTerm (f `App` e) = do
     typeCheckRefinementTerm e type_of_arg
     return type_of_return
 typeInferRefinementTerm (Coerce u 𝜏) = do
-  -- /!\ TODO XXX: This is completely wrong, if our goal (and it still is), is
-  -- for coerce to always preserve equality. Options: write some kind of
-  -- subtyping-y thing that compares the base type of the type of u with 𝜏,
-  -- without ever decomposing the base type of u further. Option 2, could be:
-  -- just prove that it is equality preserving using the underlying relation,
-  -- which doesn't have a function for yet.
-  --
-  -- Option 2 is conceptually easier and sort of what we want. But it would
-  -- still break abstract types somehow. Unless we got an abstract relation out
-  -- of them? A similar question exists for StronglyCoerce.
-  env <- ask @"env"
-  let ienv = underlyingITypes env
-  case typeCheckIntrinsicTerm ienv u (underlyingIType 𝜏) of
-    False -> error "Incorrect underlying type"
-    True -> do
-      emit (constraint 𝜏 u)
-      return 𝜏
+  typeCheckRefinementTerm u (baseType' 𝜏)
+  emit (topConstraint 𝜏 u)
+  return 𝜏
 typeInferRefinementTerm (StronglyCoerce u 𝜏) = do
   env <- ask @"env"
   let ienv = underlyingITypes env

--- a/refined-experiment/app/Main.hs
+++ b/refined-experiment/app/Main.hs
@@ -1791,6 +1791,19 @@ main = do
         --   inconsistent theory with this sort of assumptions (a set of all
         --   sets).
         --
+        --   Trying to add a full-blown universe would bring to close to
+        --   dependent types, and the problems there that we are trying to
+        --   avoid. However, Andrew Pitts teaches us in _Polymorphism is Set
+        --   Theoretic, constructively_ that we can make a universe U of types
+        --   which is stable by U-indexed product (this gives a model of System
+        --   F (a la Church, _i.e._ with explicit type abstractions and
+        --   applications)). We can surely (proof left as an exercise)
+        --   generalise this to quantifying over modules (of a given type),
+        --   which will let us quantify over groups and such. Again: explicit
+        --   module abstractions and applications. However, we won't just do
+        --   functors, like in ML, we want to have functions abstracted over
+        --   modules.
+        --
         -- - Totality: how do I characterise totality. Totality at `A → B` is
         --   fairly easy: `f` is total at `A→B`, if for every `x` total at `A`,
         --   `f x` total at `B`. But how do I define total at `ℕ`? From a

--- a/refined-experiment/app/Main.hs
+++ b/refined-experiment/app/Main.hs
@@ -158,25 +158,25 @@ instance Db.Syntax Expr where
   traverseSubs _ _ t@(NVar _) = pure t
   traverseSubs _ _ t@(Nat _) = pure t
   traverseSubs _ _ t@Succ = pure t
-  traverseSubs on_sub env (App t u) = App <$> on_sub @'TERM env t <*> on_sub @'TERM env u
-  traverseSubs on_sub env (Coerce t 𝜏) = Coerce <$> on_sub @'TERM env t <*> on_sub @'RTYPE env 𝜏
-  traverseSubs on_sub env (StronglyCoerce t 𝜏) = StronglyCoerce <$> on_sub @'TERM env t <*> on_sub @'RTYPE env 𝜏
+  traverseSubs on_sub env (App t u) = App <$> on_sub env t <*> on_sub env u
+  traverseSubs on_sub env (Coerce t 𝜏) = Coerce <$> on_sub env t <*> on_sub env 𝜏
+  traverseSubs on_sub env (StronglyCoerce t 𝜏) = StronglyCoerce <$> on_sub env t <*> on_sub env 𝜏
   traverseSubs _on_sub _env PTrue =
     pure PTrue
   traverseSubs _on_sub _env PFalse =
     pure PFalse
   traverseSubs on_sub env (PEquals t u) =
-    PEquals <$> on_sub @'TERM env t <*> on_sub @'TERM env u
+    PEquals <$> on_sub env t <*> on_sub env u
   traverseSubs on_sub env (PNot p) =
-    PNot <$> on_sub @'TERM env p
+    PNot <$> on_sub env p
   traverseSubs on_sub env (PImpl p q) =
-    PImpl <$> on_sub @'TERM env p <*> on_sub @'TERM env q
+    PImpl <$> on_sub env p <*> on_sub env q
   traverseSubs on_sub env (PEquiv p q) =
-    PEquiv <$> on_sub @'TERM env p <*> on_sub @'TERM env q
+    PEquiv <$> on_sub env p <*> on_sub env q
   traverseSubs on_sub env (PAnd p q) =
-    PAnd <$> on_sub @'TERM env p <*> on_sub @'TERM env q
+    PAnd <$> on_sub env p <*> on_sub env q
   traverseSubs on_sub env (PForall x 𝜏 p) =
-    PForall x <$> on_sub @'RTYPE env 𝜏 <*> Db.bind (on_sub @'TERM) env p
+    PForall x <$> on_sub env 𝜏 <*> Db.bind on_sub env p
 
   -- RTypes
   traverseSubs _on_sub _env RNat =
@@ -184,11 +184,11 @@ instance Db.Syntax Expr where
   traverseSubs _on_sub _env RProp =
     pure RProp
   traverseSubs on_sub env (RArrow 𝜏 𝜇) =
-    RArrow <$> on_sub @'RTYPE env 𝜏 <*> on_sub @'RTYPE env 𝜇
+    RArrow <$> on_sub env 𝜏 <*> on_sub env 𝜇
   traverseSubs on_sub env (RSub x 𝜏 p) =
-    RSub x <$> on_sub @'RTYPE env 𝜏 <*> Db.bind (on_sub @'TERM) env p
+    RSub x <$> on_sub env 𝜏 <*> Db.bind on_sub env p
   traverseSubs on_sub env (RQuotient 𝜏 r) =
-    RQuotient <$> on_sub @'RTYPE env 𝜏 <*> on_sub @'TERM env r
+    RQuotient <$> on_sub env 𝜏 <*> on_sub env r
 
 type Term = Expr 'TERM
 

--- a/refined-experiment/refined-experiment.cabal
+++ b/refined-experiment/refined-experiment.cabal
@@ -23,6 +23,7 @@ executable refined-experiment
                      , array
                      , capability
                      , containers
+                     , generic-debruijn
                      , generic-lens
                      , lens
                      , lensy-f


### PR DESCRIPTION
We use generic-debruijn to reduce boilerplate from the
refined-experiment package.

`Term` and `RType`, are now a single datatype `Expr` the distinction
between the two is given by a GADT argument to `Expr`.